### PR TITLE
Fix typos and grammar errors in documentation and API

### DIFF
--- a/docs/avl_changes.md
+++ b/docs/avl_changes.md
@@ -1,5 +1,5 @@
 OptVL is double precision by default whereas AVL is single precision
 
-add mach number reading
+Add mach number reading
 
-control surface deflection derivative fix
+Control surface deflection derivative fix

--- a/docs/building_optvl_locally.md
+++ b/docs/building_optvl_locally.md
@@ -1,9 +1,9 @@
 # Building OptVL Locally
 If you are developing OptVL you will want to install OptVL locally.
-After cloning the repo and navigating to the root directory there are two methods to actually build the python package, meson way or the make way. 
+After cloning the repo and navigating to the root directory there are two methods to actually build the python package, the meson way or the make way. 
 
 ## Using Meson
-This method exists to integration with the tools necessary to package the binaries into wheels for distribution on PYPI, 
+This method exists to integrate with the tools necessary to package the binaries into wheels for distribution on PYPI, 
 The steps are 
 1. install meson and ninja
 2. run `pip install -e .`
@@ -12,7 +12,7 @@ The `pyproject.toml` should hold all the information pip needs to use the meson 
 To modify aspects of the build, such as the compilation flags, see the `meson.build` file. 
 
 ## Using Make
-This method is more convenient for quick compilation during editing. The Steps are
+This method is more convenient for quick compilation during editing. The steps are
 1. Copy a config file from `config/defaults` to the config directory, i.e. `cp  config/defaults/config.LINUX_GFORTRAN.mk config/config.mk`
 2. Create the shared library file with `make`
 3. Install the python wrapper with `python setup_deprecated.py develop`

--- a/docs/dev_docs.md
+++ b/docs/dev_docs.md
@@ -8,10 +8,10 @@ I'm using Github to track issues and bugs so open a new issue there with any con
 # Common things you might want to modify
 Below is some information on a few development tasks that you may be interested in. 
 
-## Modify the python wrapper or OpenMDAO wrapper. 
+## Modify the python wrapper or OpenMDAO wrapper.
 The file `optvl_class.py` wraps the Fortran object file and is where the user API is defined. 
 For most development tasks this is what you will need to modify. 
-The file `om_wrapper.py` wrap the `OVLSolver` class for use with OpenMDAO. 
+The file `om_wrapper.py` wraps the `OVLSolver` class for use with OpenMDAO. 
 If you want to change something about the OpenMDAO interface, you'll need to start here. 
 
 ## Run AD on modified code
@@ -25,13 +25,13 @@ But in general there are a few places where we can loop over NVOR instead of NVM
 
 
 ## Expose an additional variable from the Fortran level
-1. in AVL.INC.in add it to the COMMON line AND declare its type above
+1. in `AVL.INC.in` add it to the COMMON line AND declare its type above
 2. replace instances of the local variable in the code with the global variable from the COMMON block
 3. navigate to `src/includes` and run `gen_ad_inc.py` 
 4. rebuild the library 
 
 ## Releasing a new version
-1. Bump the version number in pyproject.toml AND in meson.build.
+1. Bump the version number in `pyproject.toml` AND in `meson.build`.
     - I cannot figure out a way to single source this so it will have to be done in two steps for now.
-2. Then create a new release on Github. Create a new tagged version as part of the release
-3. Check that that new version has been released on PyPI as it intended
+2. Then create a new release on GitHub. Create a new tagged version as part of the release
+3. Check that that new version has been released on PyPI as intended

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,6 @@ Dive in to learn about installation, analysis, and optimization with `OptVL`.
 
 Get started with [installation](installation.md) or an [overview](overview.md)
 
-Before working with OptVL it is useful to familiarize yourself with AVL.
+Before working with OptVL, it is useful to familiarize yourself with AVL.
 More information about AVL can be found at its [website](https://web.mit.edu/drela/Public/web/avl/). 
 If you already know AVL well, then I'd advise starting with a comparison of the interfaces [here](optvl_api.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ The recommended method to install `optvl` is via pip:
 ```shell
 pip install optvl
 ```
-This package comes packaged with an OpenBLAS linear solver for quicker analysis.
+This package is packaged with an OpenBLAS linear solver for quicker analysis.
 
 ### Supported Platforms
 Currently, `optvl` supports Linux, macOS (Apple Silicon and Intel), and Windows!
@@ -26,8 +26,8 @@ You will need the following dependencies
 
 ## Post-processing
 You can use `matplotlib` for viewing the geometry and 3D surface CP data. 
-You can also install with `pip`. 
-You can also write out 3D data in the ASCII tecplot format that can be opened in either tecplot or paraview. 
+You can also install it with `pip`. 
+You can also write out 3D data in the ASCII tecplot format that can be opened in either Tecplot or Paraview. 
 
 See the section on post-processing for more details about how each of these are used. 
 

--- a/docs/making_a_movie.md
+++ b/docs/making_a_movie.md
@@ -5,8 +5,8 @@ There are many methods to do this, the one that I cover here will use ParaView.
 ## Getting the data files
 The 0-th step to making a movie/animation is to save the data that you want to visualize. 
 This data could come from a parameter sweep or optimization run for example. 
-The data read in by TecPlot and ParaView can be output using `ovl_solver.write_tecplot()`. 
-That is not a typo, ParaView can read in the TecPlot file format too, but unlike TecPlot is Free. 
+The data read in by Tecplot and ParaView can be output using `ovl_solver.write_tecplot()`. 
+That is not a typo, ParaView can read in the Tecplot file format too, but unlike Tecplot is Free. 
 To make your life much easier in ParaView you should name your files with numbered suffix like `f'wing_{idx_iter}'`. 
 If you are using OptVL via the OpenMDAO group simply set the `write_grid` option to `True` when creating the group to write out these files, i.e. `OVLGroup(geom_file="rectangle.avl", write_grid=True)`.
 
@@ -16,7 +16,7 @@ Load the stack of data to bring all the iterations of your data into ParaView.
 
 ![](figures/load_stack.png)
 
-While loading that data be sure that the TecPlot reader is used. 
+While loading that data be sure that the Tecplot reader is used. 
 
 ![](figures/tecplot_reader.png)
 

--- a/docs/making_a_movie.md
+++ b/docs/making_a_movie.md
@@ -1,22 +1,22 @@
 # How to make a movie
 
-There are many methods to do this, the one that I cover here will use Paraview. 
+There are many methods to do this, the one that I cover here will use ParaView. 
 
 ## Getting the data files
-The 0-th step to making a movie/animation is to save the data that you want to vizualize. 
+The 0-th step to making a movie/animation is to save the data that you want to visualize. 
 This data could come from a parameter sweep or optimization run for example. 
-The data read in by Tecplot and Paraview can be output using `ovl_solver.write_tecplot()`. 
-That is not a typo, Paraview can read in the Tecplot file format too, but unlike Tecplot is Free. 
-To make your life much easier in Paraview you should name your files with numbered suffix like f'wing_{idx_iter}'. 
+The data read in by TecPlot and ParaView can be output using `ovl_solver.write_tecplot()`. 
+That is not a typo, ParaView can read in the TecPlot file format too, but unlike TecPlot is Free. 
+To make your life much easier in ParaView you should name your files with numbered suffix like `f'wing_{idx_iter}'`. 
 If you are using OptVL via the OpenMDAO group simply set the `write_grid` option to `True` when creating the group to write out these files, i.e. `OVLGroup(geom_file="rectangle.avl", write_grid=True)`.
 
 ## Load the data 
-When importing data into Paraview if you named your files file_001, file_0002, ... you will see them displayed as a stack. 
-Load the stack of data to bring all the iterations of your data into Paraview. 
+When importing data into ParaView if you named your files file_001, file_0002, ... you will see them displayed as a stack (file_001, file_0002, ...). 
+Load the stack of data to bring all the iterations of your data into ParaView. 
 
 ![](figures/load_stack.png)
 
-While loading that data be sure that the Tecplot reader is used. 
+While loading that data be sure that the TecPlot reader is used. 
 
 ![](figures/tecplot_reader.png)
 
@@ -29,7 +29,7 @@ Setting the surface coloring to 'Cp' will show contours of 'Cp' on the surface.
 
 ![](figures/surface_contour_selection.png)
 
-To set the contours to your liking you will want to adjust it with the countour control bar. 
+To set the contours to your liking you will want to adjust it with the contour control bar. 
 To set the range manually you will need to click the icon with the 'C'.
 
 ![](figures/contour_options.png)
@@ -45,7 +45,7 @@ From the file menu, simply select 'save animation'.
 
 ![](figures/export_movie.png) 
 
-I had some trouble exporting the data as a .avi file from Paraview 12.0, but version 13.4 worked well. 
+I had some trouble exporting the data as a .avi file from ParaView 12.0, but version 13.4 worked well. 
 Following this process with the data from the planform optimization example, I get something like this. 
 
 ![](figures/paraview_animation.gif)

--- a/docs/making_a_script.md
+++ b/docs/making_a_script.md
@@ -1,7 +1,7 @@
 
 # Building a run script
 Here we will go over the elements of setting up and running a basic analysis in OptVL in more detail. 
-To see a complete example of a run script see the one in the [overview page](overview.md) or the [examples on github]()
+To see a complete example of a run script see the one in the [overview page](overview.md) or the [examples on GitHub]()
 
 
 ## Initializing and Setting up AVL Solver
@@ -20,7 +20,7 @@ ovl = OVLSolver(geo_file="aircraft.avl", mass_file="aircraft.mass")
 
 ## Constraints
 After initializing, you can set up various constraints directly.
-You can set `alpha`, `beta`, `roll rate`, `pitch rate`,and `yaw rate` as well any control surface in this way. 
+You can set `alpha`, `beta`, `roll rate`, `pitch rate`, and `yaw rate` as well as any control surface in this way. 
 
 ```python
 ovl.set_constraint("alpha", 0.00)
@@ -30,7 +30,7 @@ You can also set a variable in order to meet a specific constraint value.
 The valid constraint options are `CL`, `CY`, `Cl roll moment`, `Cm pitch moment`, `Cn yaw moment`.
 
 !!! Warning
-    Be careful to state a constraint variable, `con_var`, that is effected by the input. For example if you accidentally specific that the pitching moment should be trimmed by the rudder the analysis will not converge. 
+    Be careful to state a constraint variable, `con_var`, that is affected by the input. For example if you accidentally specify that the pitching moment should be trimmed by the rudder the analysis will not converge. 
 
 ```python
 # set the Elevator to trim Cm to zero
@@ -40,7 +40,7 @@ ovl.set_constraint("Rudder", 0.00, con_var="Cn yaw moment")
 ```
 
 You can also set parameters of the run case. 
-The list of parameters you can set are `CD0`, `bank`, `elevation`, `heading`, `Mach`, `velocity`, `density`, `grav.acc.`, `turn rad.`, `load fac.`, `X cg`, `Y cg`, `Z cg`, `mass`, `Ixx`, `Iyy`, `Izz`, `Ixy`, `Iyz`, `Izx`, `visc CL_a`, `visc CL_u`, `visc CM_a`, `visc CM_u`,
+The list of parameters you can set are `CD0`, `bank`, `elevation`, `heading`, `Mach`, `velocity`, `density`, `grav. acc.`, `turn rad.`, `load fac.`, `X cg`, `Y cg`, `Z cg`, `mass`, `Ixx`, `Iyy`, `Izz`, `Ixy`, `Iyz`, `Izx`, `visc CL_a`, `visc CL_u`, `visc CM_a`, `visc CM_u`,
 ```python 
 # set the flow parameters like mach numbers
 ovl.set_parameter("Mach", 0.3)
@@ -57,10 +57,10 @@ ovl.execute_run()
 For a more detailed example and advanced use cases, see the analysis guide.
 
 ## Looking at Data
-After executing the run then you can extract various output data from the solver.
+After executing the run, then you can extract various output data from the solver.
 The methods for extracting data return a dictionary of data. 
 
-To get things like CL, CD, CM, etc. use 
+To get things like CL, CD, CM, etc., use 
 ```python 
 force_data = ovl.get_total_forces()
 ```

--- a/docs/making_a_script.md
+++ b/docs/making_a_script.md
@@ -40,7 +40,7 @@ ovl.set_constraint("Rudder", 0.00, con_var="Cn yaw moment")
 ```
 
 You can also set parameters of the run case. 
-The list of parameters you can set are `CD0`, `bank`, `elevation`, `heading`, `Mach`, `velocity`, `density`, `grav. acc.`, `turn rad.`, `load fac.`, `X cg`, `Y cg`, `Z cg`, `mass`, `Ixx`, `Iyy`, `Izz`, `Ixy`, `Iyz`, `Izx`, `visc CL_a`, `visc CL_u`, `visc CM_a`, `visc CM_u`,
+The list of parameters you can set are `CD0`, `bank`, `elevation`, `heading`, `Mach`, `velocity`, `density`, `grav.acc.`, `turn rad.`, `load fac.`, `X cg`, `Y cg`, `Z cg`, `mass`, `Ixx`, `Iyy`, `Izz`, `Ixy`, `Iyz`, `Izx`, `visc CL_a`, `visc CL_u`, `visc CM_a`, `visc CM_u`,
 ```python 
 # set the flow parameters like mach numbers
 ovl.set_parameter("Mach", 0.3)

--- a/docs/modal_analysis.md
+++ b/docs/modal_analysis.md
@@ -1,7 +1,7 @@
 # Modal Analysis
 
 You can also perform eigenvalue analysis of the aircraft to characterize its dynamic stability. 
-Instead of calling `execute_run` call `execute_eigen_mode_calc`.
+Instead of calling `execute_run`, call `execute_eigen_mode_calc`.
 To run this type of analysis the aircraft should be in trim, so here we determine the CL necessary for lift = weight. 
 You must also set a velocity before the analysis with `ovl.set_parameter("velocity", <velocity>)`
 You can retrieve the eigenvalues and vectors after the analysis with `get_eigenvalues` and `get_eigenvectors`. 

--- a/docs/optimization_overview.md
+++ b/docs/optimization_overview.md
@@ -1,13 +1,13 @@
 # Optimization Overview
 
 In general, you could connect OptVL to any gradient-free or gradient-based solver. 
-In these docs, I focus on gradient-based method due to their greater efficiency. 
+In these docs, I focus on gradient-based methods due to their greater efficiency. 
 OptVL provides the derivatives, but to perform gradient-based optimization you need to pass those derivatives to an optimizer. 
 However, here I'm going to show you the two ways I recommend connecting OptVL to an optimizer, [Scipy](https://scipy.org/) and [OpenMDAO](https://openmdao.org/). 
 
-Between the two I recommend Scipy if you are doing something with few design variables and do not already know OpenMDAO. 
-However, once you start incorporating more design variables and constraints or want to use a custom geometric parameterization you are probably better off learning OpenMDAO. 
-If you are on the fence I recommend giving OpenMDAO a try. 
+Between the two, I recommend Scipy if you are doing something with few design variables and do not already know OpenMDAO. 
+However, once you start incorporating more design variables and constraints or want to use a custom geometric parameterization, you are probably better off learning OpenMDAO. 
+If you are on the fence, I recommend giving OpenMDAO a try. 
 Your optimization problem will likely only grow more complex with time and OpenMDAO will make it easier to accommodate the growth in complexity.
 
 
@@ -15,7 +15,7 @@ See optimization setup with [Scipy see this page](optimization_setup_scipy.md) a
 
 
 ## Tips
-- Don't set trim constraints (e.g. CL = 0.5) on the OptVL solver instead set it as a constraint at the optimization level. The examples all show this. 
--  Some variables (like chord, dihedral, x and z leading edge position) can lead to local minimum. 
-   To help fix this, add a constraint that keeps the variable monotonic or use a custom parameterization.
+- Don't set trim constraints (e.g. CL = 0.5) on the OptVL solver; instead, set it as a constraint at the optimization level. The examples all show this. 
+-  Some variables (like chord, dihedral, x and z leading edge position) can lead to local minima. 
+   To help fix this, add a constraint that keeps the variable monotonic, or use a custom parameterization.
 - Discontinuities can appear when moving flaps or ailerons due to sparse paneling. Use section paneling for this case to preserve good paneling at the edges of the control surfaces.  

--- a/docs/optimization_setup_om.md
+++ b/docs/optimization_setup_om.md
@@ -1,10 +1,10 @@
 # Optimizing with OpenMDAO
 
-If you don't already have OpenMDAO you can install it with `pip install OpenMDAO`
+If you don't already have OpenMDAO, you can install it with `pip install OpenMDAO`
 
 OpenMDAO doesn't actually do any of the optimization, it is simply a convenient framework for forming models for optimization. 
 It installs SciPy along with its optimizer as a dependency during the installation process. 
-If you want access to additional optimizers I recommend the [pyOptSparse library](https://github.com/mdolab/pyoptsparse).
+If you want access to additional optimizers, I recommend the [pyOptSparse library](https://github.com/mdolab/pyoptsparse).
 
 
 ## Adding OptVL to a model 
@@ -19,32 +19,32 @@ from optvl import OVLGroup
 model = om.Group()
 model.add_subsystem("ovlsolver", OVLGroup(geom_file="aircraft.avl", mass_file="aircraft.mass"))
 ```
-All the geometric variables, and `alpha` and `beta` are automatically exposed as inputs to the group. 
+All the geometric variables and `alpha` and `beta` are automatically exposed as inputs to the group. 
 The geometric variables of each surface are added as inputs of the form `<surface name>:<geo variable>`.
-To turn on other inputs such as the reference values and case parameters use the "input_param_vals" and "input_ref_vals" keywords to the group respectively.
+To turn on other inputs such as the reference values and case parameters, use the "input_param_vals" and "input_ref_vals" keywords to the group, respectively.
 ```python 
 model.add_subsystem("ovlsolver", OVLGroup(geom_file="aircraft.avl",input_param_vals=True, input_ref_vals=True))
 ```
 The force coefficients such as `CL`, `CD`, and `CM` are automatically added as outputs.
-To add stability derivatives or control surface derivatives as out just use the `output_stabililty_derivs` and `output_con_surf_derivs` keyword arguments to the group to turn them on. 
+To add stability derivatives or control surface derivatives as outputs, just use the `output_stability_derivs` and `output_con_surf_derivs` keyword arguments to the group to turn them on. 
 ```python
-model.add_subsystem("ovlsolver", OVLGroup(geom_file="aircraft.avl", output_stabililty_derivs=True, output_con_surf_derivs=True))
+model.add_subsystem("ovlsolver", OVLGroup(geom_file="aircraft.avl", output_stability_derivs=True, output_con_surf_derivs=True))
 ```
 
 ## Output options 
 
-To write out the AVL geometry and the Tecplot surface CP file at every time step use the set the option `write_grid=True`. 
-Additionally, if you are not interested in viewing the files in Paraview and instead only want to use Tecplot 360 then I also recommend adding `write_grid_sol_time=True`.
+To write out the AVL geometry and the TecPlot surface CP file at every time step, use the option `write_grid=True`. 
+Additionally, if you are not interested in viewing the files in ParaView and instead only want to use TecPlot 360, then I also recommend adding `write_grid_sol_time=True`.
 
 ```python
 model.add_subsystem("ovlsolver", OVLGroup(geom_file="aircraft.avl", write_grid=True))
-# for easier postprocessing in tecplot 360 (not compatible with paraview)
+# for easier postprocessing in TecPlot 360 (not compatible with ParaView)
 model.add_subsystem("ovlsolver", OVLGroup(geom_file="aircraft.avl", write_grid=True, write_grid_sol_time=True ))
 
 ```
 
 ## Setting design variables
-For simple optimization problems the inputs and outputs can be directly added as design variables, objective functions, and constraints. 
+For simple optimization problems, the inputs and outputs can be directly added as design variables, objective functions, and constraints. 
 
 
 ```python
@@ -52,26 +52,26 @@ For simple optimization problems the inputs and outputs can be directly added as
 model.add_design_var("ovlsolver.Wing:aincs", lower=-10, upper=10)
 model.add_design_var("ovlsolver.Elevator", lower=-10, upper=10)
 
-# the outputs of OptVL can be used as contraints
+# the outputs of OptVL can be used as constraints
 model.add_constraint("ovlsolver.CL", equals=1.5)
 model.add_constraint("ovlsolver.CM", equals=0.0, scaler=1e3)
 
-# the scaler values bring the objective functinon to ~ order 1 for the optimizer
+# the scaler values bring the objective function to ~ order 1 for the optimizer
 model.add_objective("ovlsolver.CD", scaler=1e3)
 ```
 
 ## Setting Optimizer options and running
 
-After you have setup your model you will have to apply a driver. 
-In our case our driver is the SLSQP optimizer of SciPy, but you code also apply other drivers to the model such as the DOE driver.
+After you have set up your model you will have to apply a driver. 
+In our case our driver is the SLSQP optimizer of SciPy, but you could also apply other drivers to the model such as the DOE driver.
 
-The next step is to tell OpenMDAO we are done with our problem and it can be setup with `prob.setup(mode='rev')`
+The next step is to tell OpenMDAO we are done with our problem, and it can be set up with `prob.setup(mode='rev')`
 
 !!! Warning
     When using the OptVL group we must setup the problem with `mode='rev'`. 
     OptVL uses reverse mode derivatives because in general we will have more geometric variables than output functions of interest.
 
-The line with `om.n2` creates an N2 diagram which is helpful for examining our model. 
+The line with `om.n2` creates an N2 diagram, which is helpful for examining our model. 
 See this [page](https://openmdao.org/newdocs/versions/latest/features/model_visualization/n2_details/n2_details.html) for more information on the N2 diagram.
 
 
@@ -93,7 +93,7 @@ prob.run_driver()
 
 
 ## Example script
-Below is an OpenMDAO script analogous to the SciPy based example. 
+Below is an OpenMDAO script analogous to the SciPy-based example. 
 
 
 ```python 
@@ -113,4 +113,4 @@ ovlsolver.Elevator [0.10802368]
 ovlsolver.Wing:aincs [11.46493221  1.92748591  2.14445549  2.27131259 -4.81944669]
 ovlsolver.CD [0.08554669]
 ```
-Which is about the same optimized result we got from the SciPy only based optimization. 
+Which is about the same optimized result we got from the SciPy-only based optimization. 

--- a/docs/optimization_setup_scipy.md
+++ b/docs/optimization_setup_scipy.md
@@ -1,10 +1,10 @@
 # Optimizing with SciPy
 
-Before we can use SciPy we have to install it. 
-Thankfully, SciPy is one of the best supported python packages in the world so to install it once can just use `pip install scipy`.
+Before we can use SciPy, we have to install it. 
+Thankfully, SciPy is one of the best supported python packages in the world, so to install it one can just use `pip install scipy`.
 
 SciPy has many optimizers available, but I'm going to focus on using SLSQP since it can use the gradient information from OptVL and supports constraints. 
-To use SciPy's SLSQP we will need to supply it with custom objective and constraint functions as well as the derivatives for each. 
+To use SciPy's SLSQP, we will need to supply it with custom objective and constraint functions as well as the derivatives for each. 
 These functions need to take in the design variables and apply them to our OptVL solver. 
 The snippet below provides an example of an objective function.
 ```python
@@ -18,9 +18,9 @@ The snippet below provides an example of an objective function.
 
     return cd
 ```
-Note, the objective function is specified by the return value of the function. 
-If you wanted to save data about each iteration or write output the objective function would be a good place add that functionality. 
-To supply the gradient information to SLSQP we have to define another function that returns the gradients for a given design variable vector.
+Note: the objective function is specified by the return value of the function. 
+If you wanted to save data about each iteration or write output, the objective function would be a good place to add that functionality. 
+To supply the gradient information to SLSQP, we have to define another function that returns the gradients for a given design variable vector.
 ```python
 def objective_gradient(x):
     # Partial derivatives of the objective_function
@@ -29,20 +29,20 @@ def objective_gradient(x):
     
     ovl.execute_run()
     
-    sens = ovl.execute_run_sensitivies(['CD'])
+    sens = ovl.execute_run_sensitivities(['CD'])
     dcd_dele = sens['CD']['Elevator']
     dcd_daincs = sens['CD']['Wing']['aincs']
     
     # concatinate the two and return the derivs
     return np.concatenate(([dcd_dele], dcd_daincs))
 ```
-The function `ovl.execute_run_sensitivies(['CD'])` does all the necessary work to compute the derivatives for the given list of functions. 
+The function `ovl.execute_run_sensitivities(['CD'])` does all the necessary work to compute the derivatives for the given list of functions. 
 We just need to parse the `sens` dictionary for the derivatives with respect to the design variables we are interested in.
 
-One also needs to repeat the process to create functions for the value and gradients of the constraints.
+One also needs to repeat the process for the constraints. This involves creating functions for both the constraint values and their corresponding gradients.
 
 ## Example script
-The script below shows the full optimization script for minimizing the drag of the example aircraft in trim with respect to the wing twist and elevator position. 
+The script below shows the full optimization script for minimizing the drag of the example aircraft in trim, with respect to the wing twist and elevator position. 
 
 ```python 
 {% include "../examples/run_opt_scipy.py" %}

--- a/docs/optvl_api.md
+++ b/docs/optvl_api.md
@@ -5,7 +5,7 @@ However, instead of using nested layers of options, users call the methods for g
 The tables below relate AVL commands and the corresponding method in OptVL.
 See the limitations sections for more information about commands that are not available in OptVL.
 
-|action| AVL's  "AVL" level command| OptVL api call|
+|action| AVL's  "AVL" level command| OptVL API call|
 |-----|--|--|
 |load a geometry |LOAD <geo file>|OVLSolver(geo_file=<geo file>)|
 |load a mass file |MASS <mass file> |OVLSolver(geo_file=<geo file>, mass_file=<mass file>) |
@@ -39,7 +39,7 @@ The commands from the oper and mode menus are available
 ``` -->
 
 
-|action| AVL's "OPER" command| OptVL api call|
+|action| AVL's "OPER" command| OptVL API call|
 |-----|--|--|
 |setting the angle of attack|a a <angle>| ovl.set_constraint("alpha", <angle>)|
 | set variable such that constraint = val | <variable> <constraint> <val> | ovl.set_constraint(<variable>, <val>, con_var=<constraint>) |
@@ -47,8 +47,8 @@ The commands from the oper and mode menus are available
 | run an analysis | x | ovl.execute_run() |
 | after an analysis | FT |  ovl.get_total_forces() |
 | get strip force data | ST | ovl.get_strip_forces() |
-| get shear mommen distribution | VM | ovl.get_strip_forces() |
-| get control surfaces derivatives (e.g. dCL/dElevator)| ST | ovl.get_control_derivs |
+| get shear moment distribution | VM | ovl.get_strip_forces() |
+| get control surface derivatives (e.g. dCL/dElevator)| ST | ovl.get_control_derivs() |
 | get stability derivatives | ST | ovl.get_stab_derivs()|
 | get stability derivatives in the body axis| SB | - |
 | get/set reference data | RE | ovl.get_reference_data/set_reference_data()|
@@ -60,15 +60,15 @@ The commands from the oper and mode menus are available
 | get high moments| HM | ovl.get_hinge_moments() |
 
 
-|action| AVL's mode level command| OptVL api call|
+|action| AVL's mode level command| OptVL API call|
 |-----|--|--|
 | get/set case parameters |M <var> <value>| ovl.get_reference_data(<var>)/set_reference_data(<var>, <value>)|
-| get sytem matrix | S | ovl.get_system_matrix()|
+| get system matrix | S | ovl.get_system_matrix()|
 | get eigenvalues| W | ovl.get_eigen_values()|
-| get eigenvalues| not supported | ovl.get_eigen_vectors()|
+| get eigenvectors| not supported | ovl.get_eigen_vectors()|
 | execute eigenmode calculation | N | ovl.execute_eigen_mode_calc() |
 
 ## Limitations
 1. OptVL does not support multiple run cases since this would make the wrapping and derivative code more complex. Instead, create multiple solver instances and apply different parameters to each to replicate this functionality. 
-2. There is no single precision version of OptVL available for download. You could compile one yourself if you really need this
-1. No support for working with design variables set in the AVL geometry file since we use a different system for modifying the geometry that allow the user to change any geometric parameter
+2. There is no single precision version of OptVL available for download. You could compile one yourself if you really need this.
+3. No support for working with design variables set in the AVL geometry file since we use a different system for modifying the geometry that allows the user to change any geometric parameter.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,18 +1,18 @@
 # Basic Usage Overview
 
-`OptVL` offers a python API mirroring AVL's text interface.
+`OptVL` offers a Python API mirroring AVL's text interface.
 The typical workflow involves loading a geometry file, adding constraints, and executing analysis runs.
-In addition to this though, OptVL also offers unique optimization functionality. 
+In addition to this, though, OptVL also offers unique optimization functionality. 
 
-Below is an example of a basic analysis run to give you an idea of the workflow. 
+Below is an example of a basic analysis run, to give you an idea of the workflow. 
 
 ```python 
 {% include "../examples/run_basic.py" %}
 ```
 
-The script will plot the geometry, set parameters, run an analysis and then show a CP surface plot.
+The script will plot the geometry, set parameters, run an analysis, and then show a CP surface plot.
 
-The geometry plot should looke like this 
+The geometry plot should look like this 
 ![aircraft geometry plot](figures/aircraft_geom.png)
 and the CP surface plot should look like this
 ![aircraft cp](figures/aircraft_cp.png)
@@ -24,4 +24,4 @@ You can rotate, zoom, and pan in the window to look at different parts for the a
 <!-- 2. There is no single precision version (8 digit output instead of 16 digits) of OptVL available for download
    - You could compile one yourself if you really need this -->
 2. No support for the DESIGN keyword for setting twist in the avl geometry file since we use a different system for modifying all aspects of the geometry.
-3. The windows can only use a maximum of 5000 vortices compared to the default of 6000. 
+3. OptVL on Windows can only use a maximum of 5000 vortices compared to the default of 6000. 

--- a/docs/parameter_sweeps.md
+++ b/docs/parameter_sweeps.md
@@ -7,7 +7,7 @@ This page shows how users can retrieve and set geometry parameters for parameter
 ## Getting geometry parameters
 
 To retrieve surface parameters from your AVL model, use the `get_surface_params` method.
-By default, this method only returns data about the geometry of the surface, but information about the paneling and control surfaces can also be included by passing the corresponding flags like so. 
+By default, this method only returns data about the geometry of the surface, but information about the paneling and control surfaces can also be included by passing the corresponding flags, like so: 
 ```python
 surf_data = ovl.get_surface_params(
     include_geom=True,
@@ -17,7 +17,7 @@ surf_data = ovl.get_surface_params(
 ```
 The data from `get_surface_params` come directly from the geometry file used by AVL.
 See the [AVL user guide](https://web.mit.edu/drela/Public/web/avl/avl_doc.txt) for more information about all the possible variables.
-If you only want to get a specific design variable than you can instead use
+If you only want to get a specific design variable, then you can instead use:
 ```python
 ovl.get_surface_param( <surf_name>, <param>)
 ```
@@ -40,8 +40,8 @@ To apply geometry changes to the OVLSolver object, use the `set_surface_params` 
 ovl_solver.set_surface_params(data)
 ```
 This method sets the surface parameters of the AVL model based on the provided dictionary data.
-The data pasted to this method must be a dictionary of surface names whose values are a dictionary of surface and section keywords.
-An example of such a dictionary is
+The data passed to this method must be a dictionary of surface names whose values are a dictionary of surface and section keywords.
+An example of such a dictionary is:
 ```python
 data = {
     'Wing': {
@@ -50,14 +50,14 @@ data = {
     }
 }
 ```
-The structure of the data dictionary must be the same as that returned by the `get_surface_params` method, so I recommend calling `get_surface_params` and looking at the output if you get confused.
-Similar to the getting methods, you can also set values one at a time like so
+The structure of the data dictionary must be the same as that returned by the `get_surface_params` method, so I recommend calling `get_surface_params` and looking at the output if you get confused:
+Similar to the getting methods, you can also set values one at a time like so:
 ```python
 ovl.set_surface_param( <surf_name>, <param>, <value>)
 ```
 
 ## Example modifying y scale
-To increase the span of our wing we can stretch it in the y direction by adjusting the y scale. 
+To increase the span of our wing, we can stretch it in the y direction by adjusting the y scale. 
 
 ```python 
 {% include "../examples/run_param_sweep.py" %}

--- a/docs/planform_optimization.md
+++ b/docs/planform_optimization.md
@@ -1,17 +1,19 @@
 # Planform optimization
 
+# Planform optimization
+
 This is a considerably more advanced tutorial that aims to represent a more realistic optimization problem. 
 We are going to optimize the planform of a flying wing for maximum glide duration.
-In this example we are going to walk through the platform optimization starting from a rectangular wing. 
+In this example, we are going to walk through the planform optimization starting from a rectangular wing. 
 We are going to modify the sweep of the wing with a custom parameterization that takes in the sweep design variable and sets the y coordinates of the leading edge accordingly. 
 We add additional OpenMDAO components to add this additional functionality to our optimization. 
 This is the power of OpenMDAO!
 <!-- Just add another component and OpenMDAO will figure out how to pass around the right derivative information. -->
 
 ## Custom parameterization
-AVL defines the geometry at each section, however wing planforms are generally defined with parameters that affect all sections such as sweep and taper ratio. 
+AVL defines the geometry at each section; however, wing planforms are generally defined with parameters that affect all sections such as sweep and taper ratio. 
 To modify the geometry according to traditional planform variables we need to define a custom geometry component. 
-The OpenMDAO Component below takes in the root chord, quarter chord sweep angle, and taper ratio and produces the sectional geometry needed by OptVL
+The OpenMDAO Component below takes in the root chord, quarter chord sweep angle, and taper ratio and produces the sectional geometry needed by OptVL:
 ```python
 {%
     include-markdown "../examples/run_opt_om_planform.py"
@@ -23,13 +25,13 @@ The OpenMDAO Component below takes in the root chord, quarter chord sweep angle,
 However, the component also needs the baseline section y coordinates.
 To supply this value we add a mesh component upstream of the geometry parameterization. 
 If the parameterization did not rely on these baseline values this would not be necessary.
-The N2 diagram below the show placing a mesh component upstream of the geometry component we can use the baseline values in our parameterization. 
+The N2 diagram below shows how by placing a mesh component upstream of the geometry component, we can use the baseline values in our parameterization. 
 
 ![n2 planform](figures/n2_planform.png)
 
 ## Mass properties
-When modifying the planform it is important to consider how the center of gravity and overall weight will be effected by the modification. 
-To incorporate these effects into the model a basic mass properties component computes recomputes these properties based on the planform. 
+When modifying the planform, it is important to consider how the center of gravity and overall weight will be affected by the modification. 
+To incorporate these effects into the model, a basic mass properties component recomputes these properties based on the planform. 
 This component assumes that the aircraft is cut from a material of uniform density (such as foam) to make the calculation easier. 
 ```python
 {%
@@ -64,7 +66,7 @@ Combining all these components into the OpenMDAO model we get the following scri
 ## Results
 
 The optimized design has a glide duration of over 1400 seconds.
-We can plot the objective function over the iterations using OpenMDAO's `CaseReader` class with the recorder we made. 
+We can plot the objective function over the iterations using OpenMDAO's `CaseReader` class, using the recorder we made. 
 Additionally, we can load in the last `.avl` file written during the optimization to view the geometry of the optimized design. 
 ```python
 {%
@@ -76,7 +78,7 @@ The objective function quickly rises to about 1400 seconds and then levels off.
 
 ![](figures/obj_hist_planform.png)
 
-However, if we zoom in we can see that some slight improvements are still being made to the design over the last iterations
+However, if we zoom in we can see that some slight improvements are still being made to the design over the final iterations
 
 ![](figures/obj_hist_planform_zoomed.png)
 
@@ -84,7 +86,7 @@ From the geometry we can see that the aspect ratio of the wing has increased dra
 
 ![](figures/planform_geom_opt.png)
 
-Looking at the twist and chord distribution we can see a linear chord distribution because of the taper ratio and the wash-out in the sweep. 
-The lift distribution does not look elliptical, which makes sense as maximizing glide duration is not equivalent to minimizing drag. 
+Looking at the twist and chord distribution, we can see a linear chord distribution because of the taper ratio and the wash-out in the sweep. 
+The lift distribution does not look elliptical, which makes sense, as maximizing glide duration is not equivalent to minimizing drag. 
 
 ![](figures/planform_opt_dists.png)

--- a/docs/pyavl_changes.md
+++ b/docs/pyavl_changes.md
@@ -2,10 +2,10 @@
 
 When I first started working on this project, I called it pyAVL. 
 I changed the name to OptVL for two reasons
-1. There were many other pyAVL's and people who were looking for it had trouble finding it
-2. I added lots of optimization features and wanted the name to reflect this development
+1. There were many other pyAVLs and people who were looking for it had trouble finding it
+2. I added lots of optimization features and wanted the name to reflect this development.
 While I changed the name, I decided to also make some changes to the API to better match AVL's interface. 
-The table below lists the changes. 
+The table below lists the changes.
 
 
 | pyAVL Method              | OptVL Equivalent Method   |
@@ -23,4 +23,4 @@ The table below lists the changes.
 | `executeRun`                  | use `execute_run` instead     |
 
 The output dictionaries for stability and control surface derivatives are also now flat. 
-For example instead of `cs_derivs['CL']['Elevator']` the key is now `cs_derivs['dCL/dElevator']`
+For example, instead of `cs_derivs['CL']['Elevator']` the key is now `cs_derivs['dCL/dElevator']`.

--- a/docs/sectional_data_viz.md
+++ b/docs/sectional_data_viz.md
@@ -1,12 +1,12 @@
 # Sectional Data
 
-Like AVL, OptVL also has can also plot data about each chord wise section. 
+Like AVL, OptVL can also plot data about each chordwise section. 
 This data is useful for visualizing the force distribution along the wing among other things. 
-In contrast to AVL's integrated plotter we return the data and allow you to plot it anyway you wish.
-In this demo we use `matplotlib` as it by far the most common package for plotting in python. 
+In contrast to AVL's integrated plotter, we return the data and allow you to plot it anyway you wish.
+In this demo we use `matplotlib` as it by far the most common package for plotting in Python. 
 
 ## Plotting the data 
-To get the data just call the ovl.get_strip_forces() method.
+To get the data, just call the `ovl.get_strip_forces()` method.
 The data is organized by surface and each surface has sectional geometric and force/moment data.
 ```python
 {%
@@ -15,25 +15,25 @@ The data is organized by surface and each surface has sectional geometric and fo
     end="# keys-end"
 %}
 ```
-Running the snippet above produces the list of data available for each surface. 
+Running the snippet above produces the list of data available for each surface: 
 ```
 dict_keys(['chord', 'width', 'X LE', 'Y LE', 'Z LE', 'twist', 'CL', 'CD', 'CDv', 'downwash', 'CX', 'CY', 'CZ', 'CM', 'CN', 'CR', 'CL strip', 'CD strip', 'CF strip', 'CM strip', 'CL perp', 'CM c/4', 'CM LE', 'spanloading', 'lift dist', 'drag dist'])
 ```
 
 Some data is about the geometry of the chordwise sections such as chord and twist. 
-The twist of our baseline design is all zero, but we have some variation in the chord that you can see on the plot. 
+The twist of our baseline design is all zero, but we have some variation in the chord that you can see on the plot: 
 ![sectional geometry plot](figures/sec_plot_geom.png)
 
-One of the most useful things to look at is how the lift is distributed over the wing for at our analysis condition. 
-Just like AVL you can plot the CL and the CL perpendicular to the wing of the aircraft.
+One of the most useful things to look at is how the lift is distributed over the wing at our analysis condition. 
+Just like AVL, you can plot the CL and the CL perpendicular to the wing of the aircraft.
 The lift distribution is found by multiplying the CL at each section by the chord/cref.
 ![sectional lift plot](figures/sec_plot_lift.png)
 
 You can also look at how each section contributes to the overall roll and yaw moment coefficients. 
-The roll distribution is the `CR*chord^2/cref^2` and the yaw distribution is `CN*chord^2/(cref*bref)`
+The roll distribution is the `CR*chord^2/cref^2` and the yaw distribution is `CN*chord^2/(cref*bref)`.
 ![Sectional roll yaw plot](figures/sec_plot_roll_yaw.png)
 
-## Example 
+## Example
 The example script below can be used to generate these plots for the example aircraft. 
 
 

--- a/docs/viz_overview.md
+++ b/docs/viz_overview.md
@@ -1,15 +1,15 @@
 # Visualization
 
 
-## With Matplotlib/python
-The visualizations described in this section rely on the `matplotlib` python package, but no external tools. 
+## With Matplotlib/Python
+The visualizations described in this section rely on the `matplotlib` Python package, but no external tools. 
 
 ### Looking at the geometry
 To quickly look at your geometry you can use the
 ```python
 ovl.plot_geom()
 ``` 
-command, which will produce a figure that looks like this. 
+command, which will produce a figure that looks like this: 
 ![aircraft geometry plot](figures/aircraft_geom.png)
 
 
@@ -18,49 +18,49 @@ To get a quick view of the coefficient of pressure on the surfaces of the aircra
 ```python
 ovl.plot_cp()
 ```
-Which will produce a plot like this. 
+Which will produce a plot like this: 
 
 ![aircraft cp](figures/aircraft_cp.png)
 You can rotate, zoom, and pan in the window to look at different parts for the aircraft.
 ![aircraft cp view 2](figures/aircraft_cp_view2.png)
 
-## Paraview or tecplot
-This section describes how to produce data that ca be used with either tecplot or Paraview.
+## ParaView or TecPlot
+This section describes how to produce data that can be used with either TecPlot or ParaView.
 
-To generate a tecplot ascii file (which can be read by both tecplot and paraview). 
-After and analysis use the command 
+To generate a TecPlot ASCII file (which can be read by both TecPlot and ParaView). 
+After an analysis, use the command: 
 ```python
 ovl_solver.write_tecplot('test')
 ```
-. This command will write a file called `test.dat`.
+This command will write a file called `test.dat`.
 
-### Tecplot 360
+### TecPlot 360
 
-If you load the file with Tecplot 360 it will automatically be detected as a Tecplot acii file and will be loaded accordingly. 
-By default Tecplot tends to plot the data with a 2D Cartesian plot, but you will have to switch it 3D Cartesian to see the full geometry. 
+If you load the file with TecPlot 360 it will automatically be detected as a TecPlot ASCII file and will be loaded accordingly. 
+By default, TecPlot tends to plot the data with a 2D Cartesian plot, but you will have to switch it to 3D Cartesian to see the full geometry. 
 
 ![](figures/tecplot_geom.png)
 
-You can also plot the mesh and the coefficient of pressure on the surface. 
+You can also plot the mesh and the coefficient of pressure on the surface: 
 
 ![](figures/tecplot_cp.png)
 
-When writing out the tecplot file you can also specify a solution time with the optional keyword argument. 
-This makes it easier to flip through different data files in tecplot but makes the output incompatible with paraview.
+When writing out the TecPlot file you can also specify a solution time with the optional keyword argument. 
+This makes it easier to flip through different data files in TecPlot but makes the output incompatible with ParaView.
 ```python 
 ovl_solver.write_tecplot('test', solution_time=1)
 ```
 
-## Paraview
+## ParaView
 
-When loading your data into paraview be sure to use the tecplot dat loader. 
+When loading your data into ParaView, be sure to use the TecPlot data loader. 
 
 ![](figures/paraview_loader.png)
 
-With the data loaded you can view the 3D shape, Coefficient of Pressure, and mesh just like with Tecplot. 
+With the data loaded you can view the 3D shape, Coefficient of Pressure, and mesh just like with TecPlot. 
 
 ![](figures/paraview_cp.png)
 
 
-Paraview nicely stacks up files of the same name but with different numeric suffixes and loads them into different timesteps. 
-So if you want to easily view the results of an optimization or parameter sweep name your output files the same name with a different number for the suffix. 
+ParaView nicely stacks up files of the same name but with different numeric suffixes and loads them into different timesteps. 
+So if you want to easily view the results of an optimization or parameter sweep, name your output files with the same name but a different number for the suffix. 

--- a/docs/viz_overview.md
+++ b/docs/viz_overview.md
@@ -24,20 +24,20 @@ Which will produce a plot like this:
 You can rotate, zoom, and pan in the window to look at different parts for the aircraft.
 ![aircraft cp view 2](figures/aircraft_cp_view2.png)
 
-## ParaView or TecPlot
-This section describes how to produce data that can be used with either TecPlot or ParaView.
+## ParaView or Tecplot
+This section describes how to produce data that can be used with either Tecplot or ParaView.
 
-To generate a TecPlot ASCII file (which can be read by both TecPlot and ParaView). 
+To generate a Tecplot ASCII file (which can be read by both Tecplot and ParaView). 
 After an analysis, use the command: 
 ```python
 ovl_solver.write_tecplot('test')
 ```
 This command will write a file called `test.dat`.
 
-### TecPlot 360
+### Tecplot 360
 
-If you load the file with TecPlot 360 it will automatically be detected as a TecPlot ASCII file and will be loaded accordingly. 
-By default, TecPlot tends to plot the data with a 2D Cartesian plot, but you will have to switch it to 3D Cartesian to see the full geometry. 
+If you load the file with Tecplot 360 it will automatically be detected as a Tecplot ASCII file and will be loaded accordingly. 
+By default, Tecplot tends to plot the data with a 2D Cartesian plot, but you will have to switch it to 3D Cartesian to see the full geometry. 
 
 ![](figures/tecplot_geom.png)
 
@@ -45,19 +45,19 @@ You can also plot the mesh and the coefficient of pressure on the surface:
 
 ![](figures/tecplot_cp.png)
 
-When writing out the TecPlot file you can also specify a solution time with the optional keyword argument. 
-This makes it easier to flip through different data files in TecPlot but makes the output incompatible with ParaView.
+When writing out the Tecplot file you can also specify a solution time with the optional keyword argument. 
+This makes it easier to flip through different data files in Tecplot but makes the output incompatible with ParaView.
 ```python 
 ovl_solver.write_tecplot('test', solution_time=1)
 ```
 
 ## ParaView
 
-When loading your data into ParaView, be sure to use the TecPlot data loader. 
+When loading your data into ParaView, be sure to use the Tecplot data loader. 
 
 ![](figures/paraview_loader.png)
 
-With the data loaded you can view the 3D shape, Coefficient of Pressure, and mesh just like with TecPlot. 
+With the data loaded you can view the 3D shape, Coefficient of Pressure, and mesh just like with Tecplot. 
 
 ![](figures/paraview_cp.png)
 

--- a/examples/run_opt_multipoint.py
+++ b/examples/run_opt_multipoint.py
@@ -19,7 +19,7 @@ class Top(om.Group):
         
         self.add_subsystem("perturbed_flt_cond", om.ExecComp(['ptb_alpha=alpha+0.1'], units='deg'))
         
-        self.add_subsystem("cruise_avl", OVLGroup(geom_file="aircraft.avl", mass_file="aircraft.mass", output_stabililty_derivs=True))
+        self.add_subsystem("cruise_avl", OVLGroup(geom_file="aircraft.avl", mass_file="aircraft.mass", output_stability_derivs=True))
         self.add_subsystem("perturbed_cruise_avl", OVLGroup(geom_file="aircraft.avl", mass_file="aircraft.mass"))
         
     def configure(self):

--- a/examples/run_opt_om_planform.py
+++ b/examples/run_opt_om_planform.py
@@ -182,7 +182,7 @@ model.connect("mesh.Wing:yles",['mass_props.yles'] )
 model.connect("geom_param.chords_out",['mass_props.chords'] )
 
 
-model.add_subsystem("ovlsolver", OVLGroup(geom_file="rectangle.avl", output_stabililty_derivs=True, write_grid=True, input_param_vals=True, input_ref_vals=True, output_dir='opt_output_sweep'))
+model.add_subsystem("ovlsolver", OVLGroup(geom_file="rectangle.avl", output_stability_derivs=True, write_grid=True, input_param_vals=True, input_ref_vals=True, output_dir='opt_output_sweep'))
 model.connect("geom_param.xles_out",['ovlsolver.Wing:xles'] )
 model.connect("geom_param.chords_out",['ovlsolver.Wing:chords'] )
 model.connect('mass_props.x_cg', ['ovlsolver.X cg'])

--- a/examples/run_opt_scipy.py
+++ b/examples/run_opt_scipy.py
@@ -30,7 +30,7 @@ def objective_gradient(x):
     
     ovl_solver.execute_run()
     
-    sens = ovl_solver.execute_run_sensitivies(['CD'])
+    sens = ovl_solver.execute_run_sensitivities(['CD'])
     dcd_dele = sens['CD']['Elevator']
     dcd_daincs = sens['CD']['Wing']['aincs']
 
@@ -58,7 +58,7 @@ def eq_constraint(x):
 
 # Define the gradient of the equality constraint
 def eq_constraint_jac(x):
-    sens = ovl_solver.execute_run_sensitivies(['CL', 'CM'])
+    sens = ovl_solver.execute_run_sensitivities(['CL', 'CM'])
     dcl_dele = sens['CL']['Elevator']
     dcl_daincs = sens['CL']['Wing']['aincs']
     dcl_dx = np.concatenate(([dcl_dele], dcl_daincs))

--- a/examples/run_opt_trim_scipy.py
+++ b/examples/run_opt_trim_scipy.py
@@ -21,7 +21,7 @@ def custom_function(x):
 # Define the gradient (Jacobian) of the objective function
 def custom_gradient(x):
     # Partial derivatives of the custom_function
-    sens = ovl_solver.execute_run_sensitivies(['CD'])
+    sens = ovl_solver.execute_run_sensitivities(['CD'])
     dcd_dele = sens['CD']['Elevator']
     dcd_dalpha = sens['CD']['alpha']
     # concatinate the two and return the derivs
@@ -44,7 +44,7 @@ def eq_constraint(x):
 
 # Define the gradient of the equality constraint
 def eq_constraint_jac(x):
-    sens = ovl_solver.execute_run_sensitivies(['CL', 'CM'])
+    sens = ovl_solver.execute_run_sensitivities(['CL', 'CM'])
     dcl_dele = sens['CL']['Elevator']
     dcl_dalpha = sens['CL']['alpha']
     

--- a/optvl/om_wrapper.py
+++ b/optvl/om_wrapper.py
@@ -16,7 +16,7 @@ class OVLGroup(om.Group):
         output_dir: the output directory for the files generated
         input_param_vals: flag to turn on the flght parameters (Mach, Velocity, etc.) as inputs
         input_ref_val: flag to turn on the geometric reference values (Sref, Cref, Bref) as inputs
-        output_stabililty_derivs: flag to turn on the output of stability derivatives
+        output_stability_derivs: flag to turn on the output of stability derivatives
         output_con_surf_derivs: flag to turn on the output of control surface deflections 
     """
     def initialize(self):
@@ -29,7 +29,7 @@ class OVLGroup(om.Group):
         self.options.declare("input_param_vals", types=bool, default=False)
         self.options.declare("input_ref_vals", types=bool, default=False)
         
-        self.options.declare("output_stabililty_derivs", types=bool, default=False)
+        self.options.declare("output_stability_derivs", types=bool, default=False)
         self.options.declare("output_con_surf_derivs", types=bool, default=False)
 
     def setup(self):
@@ -39,7 +39,7 @@ class OVLGroup(om.Group):
         input_param_vals = self.options["input_param_vals"]
         input_ref_vals = self.options["input_ref_vals"]
         
-        output_stabililty_derivs = self.options["output_stabililty_derivs"]
+        output_stability_derivs = self.options["output_stability_derivs"]
         output_con_surf_derivs = self.options["output_con_surf_derivs"]
 
         self.ovl = OVLSolver(geo_file=geom_file, mass_file=mass_file, debug=False)
@@ -51,7 +51,7 @@ class OVLGroup(om.Group):
         self.add_subsystem("funcs", OVLFuncsComp(ovl=self.ovl,
                                     input_param_vals=input_param_vals,
                                     input_ref_vals=input_ref_vals,
-                                    output_stabililty_derivs=output_stabililty_derivs,
+                                    output_stability_derivs=output_stability_derivs,
                                     output_con_surf_derivs=output_con_surf_derivs),
                                     promotes=["*"])
         if self.options["write_grid"]:
@@ -351,7 +351,7 @@ class OVLFuncsComp(om.ExplicitComponent):
     """
     def initialize(self):
         self.options.declare("ovl", types=OVLSolver, recordable=False)
-        self.options.declare("output_stabililty_derivs", types=bool, default=False)
+        self.options.declare("output_stability_derivs", types=bool, default=False)
         self.options.declare("output_con_surf_derivs", types=bool, default=False)
         self.options.declare("input_param_vals", types=bool, default=False)
         self.options.declare("input_ref_vals", types=bool, default=False)
@@ -389,8 +389,8 @@ class OVLFuncsComp(om.ExplicitComponent):
             for func_key in self.ovl.case_derivs_to_fort_var:
                 self.add_output(func_key)
         
-        self.output_stabililty_derivs = self.options["output_stabililty_derivs"]
-        if self.output_stabililty_derivs:
+        self.output_stability_derivs = self.options["output_stability_derivs"]
+        if self.output_stability_derivs:
             deriv_dict = self.ovl.case_stab_derivs_to_fort_var
             for func_key in deriv_dict:
                 self.add_output(func_key)        
@@ -443,7 +443,7 @@ class OVLFuncsComp(om.ExplicitComponent):
                     # var_name = f"d{func_key}_d{con_name}"
                 outputs[func_key] = consurf_derivs_seeds[func_key]
 
-        if self.output_stabililty_derivs:
+        if self.output_stability_derivs:
             stab_derivs = self.ovl.get_stab_derivs()
             for func_key in stab_derivs:
                 outputs[func_key] = stab_derivs[func_key]

--- a/optvl/optvl_class.py
+++ b/optvl/optvl_class.py
@@ -2179,7 +2179,7 @@ class OVLSolver(object):
 
         return con_seeds, geom_seeds, gamma_seeds, gamma_d_seeds, gamma_u_seeds, param_seeds, ref_seeds
 
-    def execute_run_sensitivies(self, funcs : List[str],
+    def execute_run_sensitivities(self, funcs : List[str],
                                 stab_derivs: Optional[List[str]] = None,
                                 consurf_derivs:Optional[List[str]] = None,
                                 print_timings: Optional[bool]=False) ->  Dict[str, Dict[str, float]]:

--- a/tests/test_om_wrapper.py
+++ b/tests/test_om_wrapper.py
@@ -34,7 +34,7 @@ class TestOMWrapper(unittest.TestCase):
     
         model = om.Group()
         model.add_subsystem("ovlsolver", OVLGroup(geom_file=geom_file, mass_file=mass_file, 
-                                                  output_stabililty_derivs=True,
+                                                  output_stability_derivs=True,
                                                   input_param_vals=True, input_ref_vals=True))
 
         self.prob = om.Problem(model)

--- a/tests/test_total_derivs.py
+++ b/tests/test_total_derivs.py
@@ -105,8 +105,8 @@ class TestTotals(unittest.TestCase):
         # compare the analytical gradients with finite difference for each constraint and function
         func_vars = self.ovl_solver.case_var_to_fort_var
         stab_derivs = self.ovl_solver.case_stab_derivs_to_fort_var
-        sens_funcs = self.ovl_solver.execute_run_sensitivies(func_vars)
-        sens_sd = self.ovl_solver.execute_run_sensitivies([], stab_derivs=stab_derivs, print_timings=False)
+        sens_funcs = self.ovl_solver.execute_run_sensitivities(func_vars)
+        sens_sd = self.ovl_solver.execute_run_sensitivities([], stab_derivs=stab_derivs, print_timings=False)
 
         for con_key in self.ovl_solver.con_var_to_fort_var:
             # for con_key in ['beta']:
@@ -179,9 +179,9 @@ class TestTotals(unittest.TestCase):
    
             
         stab_derivs = self.ovl_solver.case_stab_derivs_to_fort_var
-        # sens = self.ovl_solver.execute_run_sensitivies(func_vars)
+        # sens = self.ovl_solver.execute_run_sensitivities(func_vars)
         func_vars = self.ovl_solver.case_var_to_fort_var
-        sens = self.ovl_solver.execute_run_sensitivies(func_vars, consurf_derivs=consurf_vars, stab_derivs=stab_derivs, print_timings=False)
+        sens = self.ovl_solver.execute_run_sensitivities(func_vars, consurf_derivs=consurf_vars, stab_derivs=stab_derivs, print_timings=False)
 
         # for con_key in self.ovl_solver.con_var_to_fort_var:
         sens_FD = {}
@@ -282,7 +282,7 @@ class TestTotals(unittest.TestCase):
         func_vars = self.ovl_solver.case_var_to_fort_var
         stab_derivs = self.ovl_solver.case_stab_derivs_to_fort_var
 
-        sens = self.ovl_solver.execute_run_sensitivies(func_vars, stab_derivs=stab_derivs)
+        sens = self.ovl_solver.execute_run_sensitivities(func_vars, stab_derivs=stab_derivs)
 
         for param_key in self.ovl_solver.param_idx_dict:
             # for con_key in ['beta']:
@@ -346,7 +346,7 @@ class TestTotals(unittest.TestCase):
         func_vars = self.ovl_solver.case_var_to_fort_var
         stab_derivs = self.ovl_solver.case_stab_derivs_to_fort_var
 
-        sens = self.ovl_solver.execute_run_sensitivies(func_vars, stab_derivs=stab_derivs)
+        sens = self.ovl_solver.execute_run_sensitivities(func_vars, stab_derivs=stab_derivs)
 
 
         for ref_key in self.ovl_solver.ref_var_to_fort_var:


### PR DESCRIPTION
This commit fixes various typos and grammar errors found throughout the documentation files in the `docs` folder. The changes improve clarity and readability of the documentation.